### PR TITLE
Make audio_output_formats and limited_ui optional

### DIFF
--- a/carplay/catplay_carplay/src/carplay_rx/sink/audio_defaults.rs
+++ b/carplay/catplay_carplay/src/carplay_rx/sink/audio_defaults.rs
@@ -8,11 +8,11 @@ impl AirPlayReceiver {
         // --- Main Audio - Compatibility ---
         r.audio_formats.push(AudioFormatStruct {
             audio_input_formats: Some(AudioFormat::PCM_8000_MONO | AudioFormat::PCM_16000_MONO | AudioFormat::PCM_24000_MONO),
-            audio_output_formats: AudioFormat::PCM_8000_MONO
+            audio_output_formats: Some(AudioFormat::PCM_8000_MONO
                 | AudioFormat::PCM_16000_MONO
                 | AudioFormat::PCM_24000_MONO
                 | AudioFormat::PCM_44100_STEREO
-                | AudioFormat::PCM_48000_STEREO,
+                | AudioFormat::PCM_48000_STEREO),
             stream_type: StreamType::MainAudio,
             audio_type: Some(AudioType::Compatibility),
         });
@@ -20,7 +20,7 @@ impl AirPlayReceiver {
         // --- Alt Audio - Compatibility ---
         r.audio_formats.push(AudioFormatStruct {
             audio_input_formats: None,
-            audio_output_formats: AudioFormat::PCM_44100_STEREO | AudioFormat::PCM_48000_STEREO,
+            audio_output_formats: Some(AudioFormat::PCM_44100_STEREO | AudioFormat::PCM_48000_STEREO),
             stream_type: StreamType::AltAudio,
             audio_type: Some(AudioType::Compatibility),
         });
@@ -28,7 +28,7 @@ impl AirPlayReceiver {
         // --- Main Audio - Alert ---
         r.audio_formats.push(AudioFormatStruct {
             audio_input_formats: None,
-            audio_output_formats: AudioFormat::PCM_44100_STEREO | AudioFormat::PCM_48000_STEREO | AudioFormat::OPUS_48000_MONO,
+            audio_output_formats: Some(AudioFormat::PCM_44100_STEREO | AudioFormat::PCM_48000_STEREO | AudioFormat::OPUS_48000_MONO),
             stream_type: StreamType::MainAudio,
             audio_type: Some(AudioType::Alert),
         });
@@ -38,10 +38,10 @@ impl AirPlayReceiver {
             audio_input_formats: Some(
                 AudioFormat::PCM_24000_MONO | AudioFormat::PCM_16000_MONO | AudioFormat::OPUS_24000_MONO | AudioFormat::OPUS_16000_MONO,
             ),
-            audio_output_formats: AudioFormat::PCM_24000_MONO
+            audio_output_formats: Some(AudioFormat::PCM_24000_MONO
                 | AudioFormat::PCM_16000_MONO
                 | AudioFormat::OPUS_24000_MONO
-                | AudioFormat::OPUS_16000_MONO,
+                | AudioFormat::OPUS_16000_MONO),
             stream_type: StreamType::MainAudio,
             audio_type: Some(AudioType::Default),
         });
@@ -49,7 +49,7 @@ impl AirPlayReceiver {
         // --- Main Audio - Media ---
         r.audio_formats.push(AudioFormatStruct {
             audio_input_formats: None,
-            audio_output_formats: AudioFormat::PCM_44100_STEREO | AudioFormat::PCM_48000_STEREO,
+            audio_output_formats: Some(AudioFormat::PCM_44100_STEREO | AudioFormat::PCM_48000_STEREO),
             stream_type: StreamType::MainAudio,
             audio_type: Some(AudioType::Media),
         });
@@ -63,12 +63,11 @@ impl AirPlayReceiver {
                     | AudioFormat::OPUS_16000_MONO
                     | AudioFormat::OPUS_24000_MONO,
             ),
-            audio_output_formats: AudioFormat::PCM_16000_MONO
+            audio_output_formats: Some(AudioFormat::PCM_16000_MONO
                 | AudioFormat::PCM_24000_MONO
                 | AudioFormat::PCM_32000_MONO
                 | AudioFormat::OPUS_16000_MONO
-                | AudioFormat::OPUS_24000_MONO,
-
+                | AudioFormat::OPUS_24000_MONO),
             stream_type: StreamType::MainAudio,
             audio_type: Some(AudioType::Telephony),
         });
@@ -76,7 +75,7 @@ impl AirPlayReceiver {
         // --- Main Audio - SpeechRecognition (Siri) ---
         r.audio_formats.push(AudioFormatStruct {
             audio_input_formats: Some(AudioFormat::PCM_24000_MONO | AudioFormat::OPUS_24000_MONO),
-            audio_output_formats: AudioFormat::PCM_24000_MONO | AudioFormat::OPUS_24000_MONO,
+            audio_output_formats: Some(AudioFormat::PCM_24000_MONO | AudioFormat::OPUS_24000_MONO),
             stream_type: StreamType::MainAudio,
             audio_type: Some(AudioType::SpeechRecognition),
         });
@@ -84,7 +83,7 @@ impl AirPlayReceiver {
         // --- Alt Audio - Default ---
         r.audio_formats.push(AudioFormatStruct {
             audio_input_formats: None,
-            audio_output_formats: AudioFormat::PCM_44100_STEREO | AudioFormat::PCM_48000_STEREO | AudioFormat::OPUS_48000_MONO,
+            audio_output_formats: Some(AudioFormat::PCM_44100_STEREO | AudioFormat::PCM_48000_STEREO | AudioFormat::OPUS_48000_MONO),
             stream_type: StreamType::AltAudio,
             audio_type: Some(AudioType::Default),
         });
@@ -92,7 +91,7 @@ impl AirPlayReceiver {
         // --- Main High Audio - Media ---
         r.audio_formats.push(AudioFormatStruct {
             audio_input_formats: None,
-            audio_output_formats: AudioFormat::AAC_LC_48000_STEREO | AudioFormat::AAC_LC_44100_STEREO,
+            audio_output_formats: Some(AudioFormat::AAC_LC_48000_STEREO | AudioFormat::AAC_LC_44100_STEREO),
             stream_type: StreamType::MainHighAudio,
             audio_type: Some(AudioType::Media),
         });

--- a/carplay/catplay_carplay/src/msg/info.rs
+++ b/carplay/catplay_carplay/src/msg/info.rs
@@ -49,7 +49,7 @@ plist_struct! {
         #[serde(rename = "limitedUIElements", default)]
         pub limited_ui_elements: Vec<LimitedUIElement>,
         #[serde(rename = "limitedUI")]
-        pub limited_ui: FlexBool,
+        pub limited_ui: Option<FlexBool>,
         pub manufacturer: String,
         pub model: String,
         pub modes: ChangeModes,
@@ -60,12 +60,12 @@ plist_struct! {
         #[serde(default)]
         pub oem_icons: Vec<OemIcon>,
         pub oem_icon_label: Option<String>,
-        pub oem_icon_visible: FlexBool,
+        pub oem_icon_visible: Option<FlexBool>,
         #[serde(rename = "OSInfo")]
         pub os_info: Option<String>,
         /// 1.0
         pub protocol_version: Option<String>,
-        pub right_hand_drive: FlexBool,
+        pub right_hand_drive: Option<FlexBool>,
         /// SDK version
         pub source_version: String,
 
@@ -89,7 +89,7 @@ plist_struct! {
 plist_struct! {
     pub struct AudioFormatStruct {
         pub audio_input_formats: Option<AudioFormat>,
-        pub audio_output_formats: AudioFormat,
+        pub audio_output_formats: Option<AudioFormat>,
         #[serde(rename = "type")]
         pub stream_type: StreamType,
         /// Absent in v210.81


### PR DESCRIPTION
Necessary in order to connect with my test unit, a random Carplay tablet that I take it doesn't have any audio support of its own.