### PR TITLE
catplay_hap: define the aarch64 link-register macros in the asm_base.h stub

### DIFF
--- a/core/catplay_hap/build.rs
+++ b/core/catplay_hap/build.rs
@@ -185,17 +185,64 @@ fn main() {
     println!("cargo:rerun-if-changed=asm/mips_arch.h");
 }
 
+// Stand-in for BoringSSL's <openssl/asm_base.h>, which the vendored chacha20_poly1305 .S files
+// include. Only the pieces those files actually use: `_CET_ENDBR` on x86_64, and the aarch64
+// link-register macros. The aarch64 block mirrors BoringSSL's own definitions (PAC/BTI hints when
+// the compiler asks for them, empty otherwise); it does not emit the .note.gnu.property marker, so
+// objects built with -mbranch-protection just aren't marked as BTI/PAC-enabled.
+const OPENSSL_ASM_BASE_H: &str = r#"#ifndef OPENSSL_HEADER_ASM_BASE_H
+#define OPENSSL_HEADER_ASM_BASE_H
+
+#define _CET_ENDBR
+
+#if defined(__ASSEMBLER__) && defined(OPENSSL_AARCH64)
+
+#if defined(__ARM_FEATURE_BTI_DEFAULT) && __ARM_FEATURE_BTI_DEFAULT == 1
+.macro AARCH64_VALID_CALL_TARGET
+  hint #34 // bti c
+.endm
+#else
+.macro AARCH64_VALID_CALL_TARGET
+.endm
+#endif
+
+#if defined(__ARM_FEATURE_PAC_DEFAULT)
+#if ((__ARM_FEATURE_PAC_DEFAULT & 1) == 1) // signed with A-key
+.macro AARCH64_SIGN_LINK_REGISTER
+  hint #25 // paciasp
+.endm
+.macro AARCH64_VALIDATE_LINK_REGISTER
+  hint #29 // autiasp
+.endm
+#elif ((__ARM_FEATURE_PAC_DEFAULT & 2) == 2) // signed with B-key
+.macro AARCH64_SIGN_LINK_REGISTER
+  hint #27 // pacibsp
+.endm
+.macro AARCH64_VALIDATE_LINK_REGISTER
+  hint #31 // autibsp
+.endm
+#else
+#error Pointer authentication must be signed with either A or B key
+#endif
+#else
+// No pointer authentication: signing is a no-op, but the entry point still has to be a valid
+// indirect call target under BTI.
+.macro AARCH64_SIGN_LINK_REGISTER
+  AARCH64_VALID_CALL_TARGET
+.endm
+.macro AARCH64_VALIDATE_LINK_REGISTER
+.endm
+#endif
+
+#endif // __ASSEMBLER__ && OPENSSL_AARCH64
+
+#endif
+"#;
+
 fn write_openssl_asm_base_header(out_dir: &Path) {
     let include_dir = out_dir.join("openssl");
     fs::create_dir_all(&include_dir).expect("failed to create OUT_DIR/openssl");
-    fs::write(
-        include_dir.join("asm_base.h"),
-        "#ifndef OPENSSL_HEADER_ASM_BASE_H\n\
-         #define OPENSSL_HEADER_ASM_BASE_H\n\
-         #define _CET_ENDBR\n\
-         #endif\n",
-    )
-    .expect("failed to write OUT_DIR/openssl/asm_base.h");
+    fs::write(include_dir.join("asm_base.h"), OPENSSL_ASM_BASE_H).expect("failed to write OUT_DIR/openssl/asm_base.h");
 }
 
 fn prepare_poly1305_asm_sources(build: &mut cc::Build, out_dir: &Path, arch: &str, os: &str, features: &str) -> Vec<PathBuf> {


### PR DESCRIPTION
`core/catplay_hap/build.rs` generates a stand-in `openssl/asm_base.h` for the vendored BoringSSL
assembly, but it only defines `_CET_ENDBR`. The aarch64 `chacha20_poly1305_armv8-linux.S` also uses
`AARCH64_SIGN_LINK_REGISTER` / `AARCH64_VALIDATE_LINK_REGISTER`, which therefore reach the
assembler undefined:

```
chacha20_poly1305_armv8-linux.patched.S:122: Error: unknown mnemonic `aarch64_sign_link_register' -- `aarch64_sign_link_register'
chacha20_poly1305_armv8-linux.patched.S:1300: Error: unknown mnemonic `aarch64_validate_link_register' -- `aarch64_validate_link_register'
```

The x86_64 assembly doesn't use those macros, so only arm64 targets are affected — and
`chacha-armv8-linux.S` compiles fine right beside the failing file, which makes this look more
mysterious than it is.

This adds the definitions to the stub, mirroring BoringSSL's own `asm_base.h`: `paciasp`/`autiasp`
(or the B-key pair) under `__ARM_FEATURE_PAC_DEFAULT`, `bti c` under `__ARM_FEATURE_BTI_DEFAULT`,
and empty macros otherwise. The block is guarded by
`#if defined(__ASSEMBLER__) && defined(OPENSSL_AARCH64)`, so the x86_64 path is byte-for-byte
unchanged.

One deliberate omission: BoringSSL also emits a `.note.gnu.property` marker. This stub doesn't, so
objects built with `-mbranch-protection` won't be *marked* BTI/PAC-enabled even though the hints
themselves are correct. Adding it would mean reproducing more of BoringSSL's header than the two
macros these files actually need.

Verified with `cargo build --release -p catplay_hap --no-default-features --features std` on
`aarch64-unknown-linux-gnu` (Debian trixie, gcc 14.2.0), and by assembling the generated
`chacha20_poly1305_armv8-linux.patched.S` directly with the same flags `cc::Build` passes.
