### PR TITLE
carplay: add sender stats to keep-alives

### DIFF
--- a/carplay/catplay_carplay/src/screen/mod.rs
+++ b/carplay/catplay_carplay/src/screen/mod.rs
@@ -4,6 +4,7 @@ mod screen_frame_ext;
 
 pub use screen_frame::*;
 pub use screen_frame_codec::*;
+pub use screen_frame_ext::ScreenSenderStats;
 
 pub mod rx;
 #[cfg(feature = "tx")]

--- a/carplay/catplay_carplay/src/screen/rx/screen_rx_session.rs
+++ b/carplay/catplay_carplay/src/screen/rx/screen_rx_session.rs
@@ -141,6 +141,10 @@ impl TcpSession for ScreenReceiverSession {
 
             ScreenOpCode::KeepAlive | ScreenOpCode::KeepAliveWithBody => {
                 trace!("Received screen keep alive: opcode {:?}", msg.header.opcode);
+
+                if let Some(stats) = msg.sender_stats_decode() {
+                    debug!("Received screen sender stats: {stats:?}");
+                }
             }
             _ => {
                 debug!("Received unknown video frame: {:?}", msg.header);

--- a/carplay/catplay_carplay/src/screen/screen_frame_ext.rs
+++ b/carplay/catplay_carplay/src/screen/screen_frame_ext.rs
@@ -1,7 +1,8 @@
 use std::time::{Duration, Instant};
 
 use bytes::BytesMut;
-use log::debug;
+use catplay_plist::{PlistSerializable, plist_struct};
+use log::{debug, warn};
 
 use crate::{
     clock::{MediaClock, NtpU64},
@@ -217,5 +218,43 @@ impl ScreenFrame {
         let header = &mut frame.header;
         header.opcode = ScreenOpCode::KeepAlive;
         frame
+    }
+
+    pub fn keep_alive_with_stats(stats: &ScreenSenderStats) -> Self {
+        let Ok(body) = stats.pencode() else {
+            return Self::keep_alive();
+        };
+        let mut frame = ScreenFrame::default();
+        frame.header.opcode = ScreenOpCode::KeepAliveWithBody;
+        //Observed that iphone sends param[14] as frame len
+        frame.header.params[14] = Value64::from_f32(0.0, body.len() as f32);
+        frame.data = body;
+        frame
+    }
+
+    pub fn sender_stats_decode(&self) -> Option<ScreenSenderStats> {
+        if self.header.opcode != ScreenOpCode::KeepAliveWithBody {
+            return None;
+        }
+
+        match ScreenSenderStats::pdecode(&self.data) {
+            Ok(stats) => Some(stats),
+            Err(e) => {
+                warn!("Unreadable keep-alive body ({} bytes): {e:?}", self.data.len());
+                None
+            }
+        }
+    }
+}
+
+plist_struct! {
+    pub struct ScreenSenderStats {
+        /// Bytes per second written to the screen socket over the last interval.
+        pub tx_usage_avg: f64,
+        #[serde(rename = "encoderCurrentFPS")]
+        pub encoder_current_fps: u32,
+        pub sent_frames_avg: u32,
+        pub queued_frames_avg: u32,
+        pub loss_avg: f64,
     }
 }

--- a/carplay/catplay_carplay/src/screen/tx/screen_tx_session.rs
+++ b/carplay/catplay_carplay/src/screen/tx/screen_tx_session.rs
@@ -13,7 +13,7 @@ use crate::{
     cipher::AirPlayStreamEncryption,
     clock::MediaClockBox,
     rtsp_frame::{RtspError, RtspResult},
-    screen::{ScreenFrame, ScreenFrameCodec, tx::screen_tx_proxy::ScreenTransmitProxy},
+    screen::{ScreenFrame, ScreenFrameCodec, ScreenSenderStats, tx::screen_tx_proxy::ScreenTransmitProxy},
     video::{AvccConfigExtended, EncodedVideoFrame},
 };
 
@@ -49,6 +49,10 @@ pub struct ScreenTransmitSession {
 
     pending_ops: Arc<Mutex<VecDeque<ScreenTransmitOp>>>,
     nal_size_len: usize,
+    frames_since_keepalive: u32,
+    bytes_since_keepalive: u64,
+    queued_frames_sum: u64,
+    queued_frames_samples: u64,
 
     notify_frame_added: Notify,
     notify_frame_consumed: Notify,
@@ -90,6 +94,10 @@ impl ScreenTransmitSession {
             keep_alive_interval,
             last_keepalive: Instant::now(),
             nal_size_len: 4,
+            frames_since_keepalive: 0,
+            bytes_since_keepalive: 0,
+            queued_frames_sum: 0,
+            queued_frames_samples: 0,
 
             pending_ops,
             notify_frame_added,
@@ -124,6 +132,9 @@ impl TcpSession for ScreenTransmitSession {
             return Ok(());
         }
 
+        self.queued_frames_sum += ops.iter().filter(|op| op.is_frame()).count() as u64;
+        self.queued_frames_samples += 1;
+
         while let Some(elem) = ops.pop_front() {
             match elem {
                 ScreenTransmitOp::Configure(config) => {
@@ -135,6 +146,8 @@ impl TcpSession for ScreenTransmitSession {
                     warn!("Flushing video frame pts={:?} keyframe={}", frame.pts, frame.is_known_keyframe());
                     let screen_frame = ScreenFrame::video_proxied(frame, self.nal_size_len, self.clock.as_ref())
                         .map_err(|e| RtspError::UnexpectedState(format!("unexpected failure during NAL serialization: {e:?}")))?;
+                    self.frames_since_keepalive += 1;
+                    self.bytes_since_keepalive += screen_frame.data.len() as u64;
                     sink.write_composite(screen_frame)?;
                     self.notify_frame_consumed.notify();
                 }
@@ -145,8 +158,18 @@ impl TcpSession for ScreenTransmitSession {
         // Send periodic keep-alives (if outside low-power mode)
         let now = Instant::now();
         if !self.keep_alive_interval.is_zero() && now > self.last_keepalive + self.keep_alive_interval {
+            let elapsed = now.duration_since(self.last_keepalive).as_secs_f64().max(f64::MIN_POSITIVE);
+            let frames = std::mem::take(&mut self.frames_since_keepalive);
+            let stats = ScreenSenderStats {
+                tx_usage_avg: std::mem::take(&mut self.bytes_since_keepalive) as f64 / elapsed,
+                encoder_current_fps: (frames as f64 / elapsed).round() as u32,
+                sent_frames_avg: frames,
+                queued_frames_avg: (std::mem::take(&mut self.queued_frames_sum)
+                    / std::mem::replace(&mut self.queued_frames_samples, 0).max(1)) as u32,
+                loss_avg: 0.0,
+            };
             self.last_keepalive = now;
-            sink.write(ScreenFrame::keep_alive())?;
+            sink.write(ScreenFrame::keep_alive_with_stats(&stats))?;
         }
 
         if shutting_down {


### PR DESCRIPTION
Adds sender stats to tx based on a cap from a test phone, and a no-op/logging to rx. Have attached what the rx logs on a test-run.

[stats_dump.log](https://github.com/user-attachments/files/31609080/stats_dump.log)
